### PR TITLE
Added Git Metadata

### DIFF
--- a/SCRC/R/Git.R
+++ b/SCRC/R/Git.R
@@ -1,0 +1,39 @@
+
+get_author_name <- function()
+{
+    return(system("git log -1 --pretty=format:'%an'", intern=TRUE))
+}
+
+get_author_email <- function()
+{
+    return(system("git log -1 --pretty=format:'%ae'", intern=TRUE))
+}
+
+get_commit_sha1 <- function()
+{
+    return(system("git rev-parse HEAD", intern=TRUE))
+}
+
+get_commit_date <- function(commit_sha)
+{
+    return(system(paste("git show -s --format=%ci", commit_sha), intern=TRUE))
+}
+
+get_remote_url <- function()
+{
+    return(system("git config --get remote.origin.url", intern=TRUE))
+}
+
+get_tag <- function()
+{
+    return(system("git describe --dirty --tags", intern=TRUE))
+}
+
+GitMetadata <- list(
+    CommitSHA1 = get_commit_sha1(),
+    CommitDate = get_commit_date(get_commit_sha1()),
+    AuthorName = get_author_name(),
+    AuthorEmail = get_author_email(),
+    URL = get_remote_url(),
+    TAG = get_tag()
+)

--- a/SCRC/R/pushdata.R
+++ b/SCRC/R/pushdata.R
@@ -20,9 +20,14 @@ use_python(python_version)
 
 # Import the StandardAPI from the SCRC data pipeline API
 api_py <- import("data_pipeline_api.standard_api")$StandardAPI$from_config
+
+# Fetch Git Metadata
+scrc = file.path(covid_uk_path, "SCRC")
+source(try_loc(file.path(scrc, "R", "Git.R")))
+
 StandardAPI <- function(config_loc)
 {
-    return(api_py(config_loc, "test_uri", "test_git_sha"))
+    return(api_py(config_loc, GitMetadata$URL, GitMetadata$CommitSHA1))
 }
 
 # DataFrame class for conversion to Python-friendly type
@@ -30,8 +35,8 @@ pandas_df <- import("pandas")$DataFrame
 
 # Import utility and plotting functions 
 scrc = file.path(covid_uk_path, "SCRC")
-source(file.path(scrc, "R", "plotting_utils_adapted.R"))
-source(file.path(scrc, "R", "plotting_utils_basic.R"))
+source(try_loc(file.path(scrc, "R", "plotting_utils_adapted.R")))
+source(try_loc(file.path(scrc, "R", "plotting_utils_basic.R")))
 
 # Table specification for formatting outputs
 table_spec = fread(

--- a/SCRC/R/remotedata.R
+++ b/SCRC/R/remotedata.R
@@ -21,12 +21,16 @@ use_python(python_version)
 api_py <- import("data_pipeline_api.standard_api")$StandardAPI
 py_time <- import("time")$time
 
+# Fetch Git Metadata
+scrc = file.path(covid_uk_path, "SCRC")
+source(try_loc(file.path(scrc, "R", "Git.R")))
+
 # Create a function as a wrapper allowing direct usage of the API
 # FIXME: The details under the from_config method will need to be set
 # eventually to the real repository
 StandardAPI <- function(config_loc)
 {
-    return(api_py$from_config(config_loc, "test_repo", "test_git_sha"))
+    return(api_py$from_config(config_loc, GitMetadata$URL, GitMetadata$CommitSHA1))
 }
 
 #' Get the intervention

--- a/run_model.R
+++ b/run_model.R
@@ -30,10 +30,49 @@ out_file = file("current_params.txt")
 local_run = grep('--local', argv, value = FALSE)
 dump_params = grep('--dump', argv, value = FALSE) # Dump parameters prior to run and exit (for testing)
 rebuild = grep('--rebuild', argv, value = FALSE)
+help_req = grep('--help', argv, value = FALSE)
 
+help = length(help_req) > 0
 local = length(local_run) > 0
 dump_params = length(dump_params) > 0
 rebuild = length(rebuild) > 0
+
+if(help)
+{
+  help_str="
+USAGE: 
+
+  Rscript run_model.R  <n-runs> [--dump] [--local] [--rebuild] [--help]
+                       [--covid-uk-path <path-to-repo>]
+                       [--config <path-to-config-file>]
+
+Where: 
+
+  n-runs <int>
+    Number of stochastic realisations (model runs) to perform
+  
+  --dump
+    Run model in dump mode, creating parameters then exitting (for debugging purposes)
+
+  --local
+    Run model in 'vanilla' mode using the local datasets in a manner closer to the original
+    execution method
+
+  --rebuild
+    Rebuild the Rcpp source code before running
+
+  --help
+    Print this help string
+
+  --covid-uk-path <string>
+    Location of the covid-uk repository (if running from an external location)
+
+  --config <string>
+    Path to the 'config.yaml' file for data retrieval and creation via the SCRC API 
+"
+  cat(help_str)
+  quit(status=0)
+}
 
 n_runs = as.numeric(argv[1]);
 


### PR DESCRIPTION
Calls to the SCRC API now no longer use dummy variables for `uri` and `git_sha`. Instead a new script `Git.R` finds the relevant metadata for these arguments.
Closes https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/747